### PR TITLE
:zap: Improve regexp rule

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -75,7 +75,7 @@ func RegexRule(regexPattern string) func(event *Event, state State) bool {
 	regex := regexp.MustCompile(regexPattern)
 	return func(event *Event, state State) bool {
 		msg := event.Message.CQString()
-		state["regex_matched"] = regex.FindAllString(msg, -1)
+		state["regex_matched"] = regex.FindStringSubmatch(msg)
 		if state["regex_matched"] != nil {
 			return false
 		}


### PR DESCRIPTION
> func (*Regexp) FindStringSubmatch
> func (re *Regexp) FindStringSubmatch(s string) []string
> FindStringSubmatch returns a slice of strings holding the text of the leftmost match of the regular expression in s and the matches, if any, of its subexpressions, as defined by the 'Submatch' description in the package comment. A return value of nil indicates no match.

使用 `FindStringSubmatch` 可以返回具体匹配到的字符串以及参数