### PR TITLE
add RawEvent field to event struct

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -106,6 +106,7 @@ func processEvent(response []byte) {
 
 	var event Event
 	_ = json.Unmarshal(response, &event)
+	event.RawEvent = response
 	switch event.PostType { // process DetailType
 	case "message":
 		event.DetailType = event.MessageType

--- a/types.go
+++ b/types.go
@@ -73,6 +73,7 @@ type Event struct {
 	Sender        *User               `json:"sender"`
 	NativeMessage jsoniter.RawMessage `json:"message"`
 	IsToMe        bool                `json:"-"`
+	RawEvent      []byte              `json:"-"`
 }
 
 type Message struct {


### PR DESCRIPTION
目前 Event 有些字段缺失，有些数据无法获取。而且在不同的 `onebot` 实现中，字段也有所不同，难以全面覆盖。所以使用 `RawEvent` 传递原始事件。