### PR TITLE
Fix null message check

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -145,7 +145,7 @@ func preprocessMessageEvent(e *Event) {
 				}
 			}
 		}
-		if e.Message == nil || e.Message[0].Type != "text" {
+		if e.Message == nil || len(e.Message) == 0 || e.Message[0].Type != "text" {
 			return
 		}
 		e.Message[0].Data["text"] = strings.TrimLeft(e.Message[0].Data["text"], " ") // Trim!
@@ -158,6 +158,9 @@ func preprocessMessageEvent(e *Event) {
 			}
 		}
 	}()
+	if e.Message == nil || len(e.Message) == 0 || e.Message[0].Type != "text" {
+		return
+	}
 	e.Message[0].Data["text"] = strings.TrimLeft(e.Message[0].Data["text"], " ") // Trim Again!
 }
 


### PR DESCRIPTION
复现：
```仅@机器人```

日志：
```
time="2021-01-13T18:21:35+08:00" level=error msg="handle event err: runtime error: index out of range [0] with length 0\ngoroutine 35 [running]:\nruntime/debug.Stack(0xc00004d9f0, 0x8526a0, 0xc0000980e0)\n\tc:/go/src/runtime/debug/stack.go:24 +0xa4\ngithub.com/wdvxdr1123/ZeroBot.processEvent.func1()\n\tC:/Users/Tony/go/pkg/mod/github.com/wdvxdr1123/!zero!bot@v0.0.0-20201229053652-925397d79024/bot.go:93 +0x5e\npanic(0x8526a0, 0xc0000980e0)\n\tc:/go/src/runtime/panic.go:969 +0x174\ngithub.com/wdvxdr1123/ZeroBot.preprocessMessageEvent(0xc000084180)\n\tC:/Users/Tony/go/pkg/mod/github.com/wdvxdr1123/!zero!bot@v0.0.0-20201229053652-925397d79024/bot.go:164 +0x233\ngithub.com/wdvxdr1123/ZeroBot.processEvent(0xc0001c0c00, 0x193, 0x600, 0x5, 0xc000092000, 0x193, 0x0, 0x0, 0x0, 0x0)\n\tC:/Users/Tony/go/pkg/mod/github.com/wdvxdr1123/!zero!bot@v0.0.0-20201229053652-925397d79024/bot.go:108 +0x3df\ncreated by github.com/wdvxdr1123/ZeroBot.handleResponse\n\tC:/Users/Tony/go/pkg/mod/github.com/wdvxdr1123/!zero!bot@v0.0.0-20201229053652-925397d79024/bot.go:86 +0x7d9\n"
```