### PR TITLE
fix: change CommandRule from HasPrefix to Split

### DIFF
--- a/Zero.code-workspace
+++ b/Zero.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/rules.go
+++ b/rules.go
@@ -90,14 +90,16 @@ func CommandRule(commands ...string) Rule {
 		}
 		cmdMessage := firstMessage[len(BotConfig.CommandPrefix):]
 		for _, command := range commands {
-			if strings.HasPrefix(cmdMessage, command) {
-				ctx.State["command"] = command
-				arg := strings.TrimLeft(cmdMessage[len(command):], " ")
-				if len(ctx.Event.Message) > 1 {
-					arg += ctx.Event.Message[1:].ExtractPlainText()
-				}
-				ctx.State["args"] = arg
-				return true
+			if msgs := strings.FieldsFunc(cmdMessage, func (r rune) bool {
+					return r==' ' || r==',' || r=='-' || r=='|' || r=='_' || r=='/' || r=='+' || r==';' || r=='.'
+				}); msgs[0] == command {
+					ctx.State["command"] = command
+					arg := strings.TrimLeft(cmdMessage[len(command)+1:], " ")
+					if len(ctx.Event.Message) > 1 {
+						arg += ctx.Event.Message[1:].ExtractPlainText()
+					}
+					ctx.State["args"] = arg
+					return true
 			}
 		}
 		return false


### PR DESCRIPTION
如 #38 描述，OnCommand 只判断前缀，感觉不是特别符合一般人的认知，比如 `hello` 和 `hello123` 严格来讲应该是两个命令才对，所以改成先分割再判断

Ps. 希望能再多点注释，不管英文的还是中文的，就两个英文单词放那里啃起来时间耗费的多了一点