### PR TITLE
fix: change CommandRule from HasPrefix to Split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.code-workspace
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ TODO
 
 # todo
 /extension/template
+
+# macos
+.DS_Store

--- a/api.go
+++ b/api.go
@@ -341,3 +341,16 @@ func (ctx *Ctx) GetWordSlices(content string) gjson.Result {
 		"content": content,
 	}).Data
 }
+
+func (ctx *Ctx) SendGuildChannelMessage(guildID, channelID int64, message interface{}) string {
+	rsp := ctx.CallAction("send_guild_channel_msg", Params{
+		"guild_id":   guildID,
+		"channel_id": channelID,
+		"message":    message,
+	}).Data.Get("message_id")
+	if rsp.Exists() {
+		log.Infof("发送频道消息(%v-%v): %v (id=%v)", guildID, channelID, formatMessage(message), rsp.Int())
+		return rsp.String()
+	}
+	return "0" // 无法获取返回值
+}

--- a/api.go
+++ b/api.go
@@ -342,7 +342,7 @@ func (ctx *Ctx) GetWordSlices(content string) gjson.Result {
 	}).Data
 }
 
-func (ctx *Ctx) SendGuildChannelMessage(guildID, channelID int64, message interface{}) string {
+func (ctx *Ctx) SendGuildChannelMessage(guildID, channelID string, message interface{}) string {
 	rsp := ctx.CallAction("send_guild_channel_msg", Params{
 		"guild_id":   guildID,
 		"channel_id": channelID,

--- a/api.go
+++ b/api.go
@@ -70,17 +70,19 @@ func (ctx *Ctx) SendPrivateMessage(userID int64, message interface{}) int64 {
 
 // DeleteMessage 撤回消息
 // https://github.com/botuniverse/onebot-11/blob/master/api/public.md#delete_msg-%E6%92%A4%E5%9B%9E%E6%B6%88%E6%81%AF
+//nolint:interfacer
 func (ctx *Ctx) DeleteMessage(messageID message.MessageID) {
 	ctx.CallAction("delete_msg", Params{
-		"message_id": messageID,
+		"message_id": messageID.String(),
 	})
 }
 
 // GetMessage 获取消息
 // https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_msg-%E8%8E%B7%E5%8F%96%E6%B6%88%E6%81%AF
+//nolint:interfacer
 func (ctx *Ctx) GetMessage(messageID message.MessageID) Message {
 	rsp := ctx.CallAction("get_msg", Params{
-		"message_id": messageID,
+		"message_id": messageID.String(),
 	}).Data
 	m := Message{
 		Elements:    message.ParseMessage(helper.StringToBytes(rsp.Get("message").Raw)),

--- a/api.go
+++ b/api.go
@@ -70,7 +70,7 @@ func (ctx *Ctx) SendPrivateMessage(userID int64, message interface{}) int64 {
 
 // DeleteMessage 撤回消息
 // https://github.com/botuniverse/onebot-11/blob/master/api/public.md#delete_msg-%E6%92%A4%E5%9B%9E%E6%B6%88%E6%81%AF
-func (ctx *Ctx) DeleteMessage(messageID int64) {
+func (ctx *Ctx) DeleteMessage(messageID message.MessageID) {
 	ctx.CallAction("delete_msg", Params{
 		"message_id": messageID,
 	})
@@ -78,13 +78,13 @@ func (ctx *Ctx) DeleteMessage(messageID int64) {
 
 // GetMessage 获取消息
 // https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_msg-%E8%8E%B7%E5%8F%96%E6%B6%88%E6%81%AF
-func (ctx *Ctx) GetMessage(messageID int64) Message {
+func (ctx *Ctx) GetMessage(messageID message.MessageID) Message {
 	rsp := ctx.CallAction("get_msg", Params{
 		"message_id": messageID,
 	}).Data
 	m := Message{
 		Elements:    message.ParseMessage(helper.StringToBytes(rsp.Get("message").Raw)),
-		MessageId:   rsp.Get("message_id").Int(),
+		MessageId:   message.NewMessageID(rsp.Get("message_id").Raw),
 		MessageType: rsp.Get("message_type").String(),
 		Sender:      &User{},
 	}

--- a/bot.go
+++ b/bot.go
@@ -75,9 +75,17 @@ func processEvent(response []byte, caller APICaller) {
 			log.Errorf("handle event err: %v\n%v", pa, string(debug.Stack()))
 		}
 	}()
+
 	var event Event
 	_ = json.Unmarshal(response, &event)
 	event.RawEvent = gjson.Parse(helper.BytesToString(response))
+	messageID, err := strconv.ParseInt(helper.BytesToString(event.RawMessageID), 10, 64)
+	if err == nil {
+		event.MessageID = messageID
+	} else {
+		event.MessageID, _ = strconv.Unquote(helper.BytesToString(event.RawMessageID))
+	}
+
 	switch event.PostType { // process DetailType
 	case "message", "message_sent":
 		event.DetailType = event.MessageType

--- a/bot.go
+++ b/bot.go
@@ -186,8 +186,7 @@ func preprocessMessageEvent(e *Event) {
 		log.Infof("收到群(%v)消息 %v : %v", e.GroupID, e.Sender.String(), e.RawMessage)
 		processAt()
 	case e.DetailType == "guild" && e.SubType == "channel":
-		log.Infof("收到频道(%v-%v)消息 %v : %v", e.RawEvent.Get("guild_id"), e.RawEvent.Get("channel_id"),
-			e.Sender.String(), e.Message)
+		log.Infof("收到频道(%v-%v)消息 %v : %v", e.GuildID, e.ChannelID, e.Sender.String(), e.Message)
 		processAt()
 	default:
 		e.IsToMe = true // 私聊也判断为at

--- a/context.go
+++ b/context.go
@@ -81,10 +81,16 @@ func (ctx *Ctx) CheckSession() Rule {
 
 // Send 快捷发送消息
 func (ctx *Ctx) Send(message interface{}) int64 {
-	if ctx.Event.GroupID != 0 {
-		return ctx.SendGroupMessage(ctx.Event.GroupID, message)
+	event := ctx.Event
+	if event.DetailType == "guild" {
+		raw := event.RawEvent
+		ctx.SendGuildChannelMessage(raw.Get("guild_id").Int(), raw.Get("channel_id").Int(), message)
+		return -1 // unsupported
 	}
-	return ctx.SendPrivateMessage(ctx.Event.UserID, message)
+	if event.GroupID != 0 {
+		return ctx.SendGroupMessage(event.GroupID, message)
+	}
+	return ctx.SendPrivateMessage(event.UserID, message)
 }
 
 // SendChain 快捷发送消息-消息链

--- a/context.go
+++ b/context.go
@@ -95,10 +95,7 @@ func (ctx *Ctx) Send(message interface{}) int64 {
 
 // SendChain 快捷发送消息-消息链
 func (ctx *Ctx) SendChain(message ...message.MessageSegment) int64 {
-	if ctx.Event.GroupID != 0 {
-		return ctx.SendGroupMessage(ctx.Event.GroupID, message)
-	}
-	return ctx.SendPrivateMessage(ctx.Event.UserID, message)
+	return ctx.Send(message)
 }
 
 // FutureEvent ...

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package zero
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/wdvxdr1123/ZeroBot/message"
@@ -80,21 +81,19 @@ func (ctx *Ctx) CheckSession() Rule {
 }
 
 // Send 快捷发送消息
-func (ctx *Ctx) Send(message interface{}) int64 {
+func (ctx *Ctx) Send(msg interface{}) message.MessageID {
 	event := ctx.Event
 	if event.DetailType == "guild" {
-		raw := event.RawEvent
-		ctx.SendGuildChannelMessage(raw.Get("guild_id").Int(), raw.Get("channel_id").Int(), message)
-		return -1 // unsupported
+		return message.NewMessageID(ctx.SendGuildChannelMessage(event.GuildID, event.ChannelID, msg))
 	}
 	if event.GroupID != 0 {
-		return ctx.SendGroupMessage(event.GroupID, message)
+		return message.NewMessageID(strconv.FormatInt(ctx.SendGroupMessage(event.GroupID, msg), 10))
 	}
-	return ctx.SendPrivateMessage(event.UserID, message)
+	return message.NewMessageID(strconv.FormatInt(ctx.SendPrivateMessage(event.UserID, msg), 10))
 }
 
 // SendChain 快捷发送消息-消息链
-func (ctx *Ctx) SendChain(message ...message.MessageSegment) int64 {
+func (ctx *Ctx) SendChain(message ...message.MessageSegment) message.MessageID {
 	return ctx.Send(message)
 }
 

--- a/rules.go
+++ b/rules.go
@@ -93,14 +93,16 @@ func CommandRule(commands ...string) Rule {
 		}
 		cmdMessage := firstMessage[len(BotConfig.CommandPrefix):]
 		for _, command := range commands {
-			if strings.HasPrefix(cmdMessage, command) {
-				ctx.State["command"] = command
-				arg := strings.TrimLeft(cmdMessage[len(command):], " ")
-				if len(ctx.Event.Message) > 1 {
-					arg += ctx.Event.Message[1:].ExtractPlainText()
-				}
-				ctx.State["args"] = arg
-				return true
+			if msgs := strings.FieldsFunc(cmdMessage, func (r rune) bool {
+					return r==' ' || r==',' || r=='-' || r=='|' || r=='_' || r=='/' || r=='+' || r==';' || r=='.'
+				}); msgs[0] == command {
+					ctx.State["command"] = command
+					arg := strings.TrimLeft(cmdMessage[len(command)+1:], " ")
+					if len(ctx.Event.Message) > 1 {
+						arg += ctx.Event.Message[1:].ExtractPlainText()
+					}
+					ctx.State["args"] = arg
+					return true
 			}
 		}
 		return false

--- a/rules.go
+++ b/rules.go
@@ -97,7 +97,10 @@ func CommandRule(commands ...string) Rule {
 					return r==' ' || r==',' || r=='-' || r=='|' || r=='_' || r=='/' || r=='+' || r==';' || r=='.'
 				}); msgs[0] == command {
 					ctx.State["command"] = command
-					arg := strings.TrimLeft(cmdMessage[len(command)+1:], " ")
+					arg := ""
+					if len(cmdMessage) > len(command) {
+						arg = strings.TrimLeft(cmdMessage[len(command)+1:], " ")
+					}
 					if len(ctx.Event.Message) > 1 {
 						arg += ctx.Event.Message[1:].ExtractPlainText()
 					}

--- a/types.go
+++ b/types.go
@@ -61,11 +61,16 @@ type Event struct {
 	DetailType    string          `json:"-"`
 	MessageType   string          `json:"message_type"`
 	SubType       string          `json:"sub_type"`
-	MessageID     int64           `json:"message_id"`
+	MessageID     interface{}     // int64 in qq or string in guild
+	RawMessageID  json.RawMessage `json:"message_id"` // int64 in qq or string in guild
 	GroupID       int64           `json:"group_id"`
+	ChannelID     int64           `json:"channel_id"`
+	GuildID       int64           `json:"guild_id"`
 	UserID        int64           `json:"user_id"`
+	TinyID        int64           `json:"tiny_id"`
 	TargetID      int64           `json:"target_id"`
 	SelfID        int64           `json:"self_id"`
+	SelfTinyID    int64           `json:"self_tiny_id"`
 	RawMessage    string          `json:"raw_message"` // raw_message is always string
 	Anonymous     interface{}     `json:"anonymous"`
 	AnonymousFlag string          `json:"anonymous_flag"` // This field is deprecated and will get removed, see #11
@@ -86,7 +91,7 @@ type Event struct {
 // Message 消息
 type Message struct {
 	Elements    message.Message
-	MessageId   int64
+	MessageId   message.MessageID
 	Sender      *User
 	MessageType string
 }

--- a/types.go
+++ b/types.go
@@ -38,6 +38,7 @@ type User struct {
 	// Private sender
 	// https://github.com/botuniverse/onebot-11/blob/master/event/message.md#%E7%A7%81%E8%81%8A%E6%B6%88%E6%81%AF
 	ID       int64  `json:"user_id"`
+	TinyID   string `json:"tiny_id"` // TinyID 在 guild 下为 ID 的 string
 	NickName string `json:"nickname"`
 	Sex      string `json:"sex"` // "male"、"female"、"unknown"
 	Age      int    `json:"age"`
@@ -64,13 +65,13 @@ type Event struct {
 	MessageID     interface{}     // int64 in qq or string in guild
 	RawMessageID  json.RawMessage `json:"message_id"` // int64 in qq or string in guild
 	GroupID       int64           `json:"group_id"`
-	ChannelID     int64           `json:"channel_id"`
-	GuildID       int64           `json:"guild_id"`
+	ChannelID     string          `json:"channel_id"`
+	GuildID       string          `json:"guild_id"`
 	UserID        int64           `json:"user_id"`
-	TinyID        int64           `json:"tiny_id"`
+	TinyID        string          `json:"tiny_id"`
 	TargetID      int64           `json:"target_id"`
 	SelfID        int64           `json:"self_id"`
-	SelfTinyID    int64           `json:"self_tiny_id"`
+	SelfTinyID    string          `json:"self_tiny_id"`
 	RawMessage    string          `json:"raw_message"` // raw_message is always string
 	Anonymous     interface{}     `json:"anonymous"`
 	AnonymousFlag string          `json:"anonymous_flag"` // This field is deprecated and will get removed, see #11


### PR DESCRIPTION
fix: change CommandRule from HasPrefix to Split

如 #38 描述，OnCommand 只判断前缀，感觉不是特别符合一般人的认知，比如 `hello` 和 `hello123` 严格来讲应该是两个命令才对，所以改成先分割再判断

Ps. 希望能再多点注释，不管英文的还是中文的，就两个英文单词放那里啃起来时间耗费的多了一点

Ps. 刚才不小心把vscode的code-workspace文件推送上来了，重新PR一下