### PR TITLE
[fix]修复临时会话消息被错误发送到群聊的bug

### DIFF
--- a/context.go
+++ b/context.go
@@ -88,27 +88,65 @@ func (ctx *Ctx) CheckSession() Rule {
 // Send 快捷发送消息/合并转发
 func (ctx *Ctx) Send(msg interface{}) message.ID {
 	event := ctx.Event
+
 	m, ok := msg.(message.Message)
 	if !ok {
-		var p *message.Message
-		p, ok = msg.(*message.Message)
-		if ok {
+		if p, ok2 := msg.(*message.Message); ok2 {
 			m = *p
+			ok = true
 		}
 	}
+
+	// 合并转发
 	if ok && len(m) > 0 && m[0].Type == "node" && event.DetailType != "guild" {
-		if event.GroupID != 0 {
-			return message.NewMessageIDFromInteger(ctx.SendGroupForwardMessage(event.GroupID, m).Get("message_id").Int())
+
+		switch event.MessageType {
+		case "group":
+			return message.NewMessageIDFromInteger(
+				ctx.SendGroupForwardMessage(event.GroupID, m).Get("message_id").Int(),
+			)
+
+		case "private":
+			return message.NewMessageIDFromInteger(
+				ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int(),
+			)
+		default:
+			if event.GroupID != 0 {
+				return message.NewMessageIDFromInteger(
+					ctx.SendGroupForwardMessage(event.GroupID, m).Get("message_id").Int(),
+				)
+			}
+			return message.NewMessageIDFromInteger(
+				ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int(),
+			)
 		}
-		return message.NewMessageIDFromInteger(ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int())
 	}
+
 	if event.DetailType == "guild" {
-		return message.NewMessageIDFromString(ctx.SendGuildChannelMessage(event.GuildID, event.ChannelID, msg))
+		return message.NewMessageIDFromString(
+			ctx.SendGuildChannelMessage(event.GuildID, event.ChannelID, msg),
+		)
 	}
-	if event.GroupID != 0 {
-		return message.NewMessageIDFromInteger(ctx.SendGroupMessage(event.GroupID, msg))
+
+	switch event.MessageType {
+	case "group":
+		return message.NewMessageIDFromInteger(
+			ctx.SendGroupMessage(event.GroupID, msg),
+		)
+	case "private":
+		return message.NewMessageIDFromInteger(
+			ctx.SendPrivateMessage(event.UserID, msg),
+		)
+	default:
+		if event.GroupID != 0 {
+			return message.NewMessageIDFromInteger(
+				ctx.SendGroupMessage(event.GroupID, msg),
+			)
+		}
+		return message.NewMessageIDFromInteger(
+			ctx.SendPrivateMessage(event.UserID, msg),
+		)
 	}
-	return message.NewMessageIDFromInteger(ctx.SendPrivateMessage(event.UserID, msg))
 }
 
 // SendChain 快捷发送消息/合并转发-消息链

--- a/context.go
+++ b/context.go
@@ -90,13 +90,13 @@ func (ctx *Ctx) Send(msg interface{}) message.ID {
 	event := ctx.Event
 
 	m, ok := msg.(message.Message)
-	        if !ok {
-                var p *message.Message
-                p, ok = msg.(*message.Message)
-                if ok {
-                        m = *p
-                }
-        }
+	if !ok {
+		var p *message.Message
+		p, ok = msg.(*message.Message)
+		if ok {
+			m = *p
+		}
+	}
 
 	// 合并转发
 	if ok && len(m) > 0 && m[0].Type == "node" && event.DetailType != "guild" {

--- a/context.go
+++ b/context.go
@@ -110,16 +110,15 @@ func (ctx *Ctx) Send(msg interface{}) message.ID {
 			return message.NewMessageIDFromInteger(
 				ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int(),
 			)
-		default:
-			if event.GroupID != 0 {
-				return message.NewMessageIDFromInteger(
-					ctx.SendGroupForwardMessage(event.GroupID, m).Get("message_id").Int(),
-				)
-			}
+		}
+		if event.GroupID != 0 {
 			return message.NewMessageIDFromInteger(
-				ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int(),
+				ctx.SendGroupForwardMessage(event.GroupID, m).Get("message_id").Int(),
 			)
 		}
+		return message.NewMessageIDFromInteger(
+			ctx.SendPrivateForwardMessage(event.UserID, m).Get("message_id").Int(),
+		)
 	}
 
 	if event.DetailType == "guild" {
@@ -137,16 +136,15 @@ func (ctx *Ctx) Send(msg interface{}) message.ID {
 		return message.NewMessageIDFromInteger(
 			ctx.SendPrivateMessage(event.UserID, msg),
 		)
-	default:
-		if event.GroupID != 0 {
-			return message.NewMessageIDFromInteger(
-				ctx.SendGroupMessage(event.GroupID, msg),
-			)
-		}
+	}
+	if event.GroupID != 0 {
 		return message.NewMessageIDFromInteger(
-			ctx.SendPrivateMessage(event.UserID, msg),
+			ctx.SendGroupMessage(event.GroupID, msg),
 		)
 	}
+	return message.NewMessageIDFromInteger(
+		ctx.SendPrivateMessage(event.UserID, msg),
+	)
 }
 
 // SendChain 快捷发送消息/合并转发-消息链

--- a/context.go
+++ b/context.go
@@ -90,12 +90,13 @@ func (ctx *Ctx) Send(msg interface{}) message.ID {
 	event := ctx.Event
 
 	m, ok := msg.(message.Message)
-	if !ok {
-		if p, ok2 := msg.(*message.Message); ok2 {
-			m = *p
-			ok = true
-		}
-	}
+	        if !ok {
+                var p *message.Message
+                p, ok = msg.(*message.Message)
+                if ok {
+                        m = *p
+                }
+        }
 
 	// 合并转发
 	if ok && len(m) > 0 && m[0].Type == "node" && event.DetailType != "guild" {


### PR DESCRIPTION
这个pr是为了修复
此前通过 `GroupID != 0` 判断消息发送目标（群聊/私聊），
但在 临时会话（私聊）也可能包含 `GroupID`，
导致消息被错误发送到群聊。
此前的效果图，如果有reply则会
<img width="367" height="385" alt="image" src="https://github.com/user-attachments/assets/c0cdec9f-a80e-47c6-b711-10a48103018a" />
